### PR TITLE
fix: Do not overwrite whole file when updating version

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,17 +89,14 @@ export async function updateVersionJson (file: string, context: VerifyReleaseCon
 
     context.logger.log(`Updating version in ${file}`);
     const content = await readFile(file, 'utf8');
+    const json = JSON.parse(content);
+    if (json.version === context.nextRelease.version) {
+        context.logger.log(`Skipped, ${file} is already up to date`);
+        return;
+    }
 
     const versionRegex = /("version"\s*:\s*")(\d+\.\d+\.\d+)(")/;
-    const currentVersionMatch = content.match(versionRegex);
     const nextVersion = context.nextRelease.version;
-    if (currentVersionMatch && currentVersionMatch.length > 2) {
-        const currentVersion = currentVersionMatch[2];
-        if (currentVersion === nextVersion) {
-            context.logger.log(`Skipped, ${file} is already up to date`);
-            return;
-        }
-    }
 
     const updatedContent = content.replace(versionRegex, `$1${nextVersion}$3`);
 

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -87,7 +87,6 @@ describe('Utils', function () {
         let tmpDir: string;
         let filePath: string;
 
-
         beforeEach(async () => {
             tmpDir = await mkdtemp(
                 join(tmpdir(), 'semantic-release-jsr-'),
@@ -161,9 +160,7 @@ describe('Utils', function () {
             });
         });
         describe('same version', function () {
-
             it('should skip when version is already up to date', async function () {
-
                 const mockFile = '{ "version": "1.2.3" }';
 
                 await writeFile(filePath, mockFile, 'utf8');

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -83,75 +83,117 @@ describe('Utils', function () {
             });
         });
     });
-    describe("updateVersionJson()", function () {
-        it("should update version if they are different", async function () {
-            const tmpDir = await mkdtemp(
-                join(tmpdir(), "semantic-release-jsr-"),
+    describe('updateVersionJson()', async function () {
+        let tmpDir: string;
+        let filePath: string;
+
+
+        beforeEach(async () => {
+            tmpDir = await mkdtemp(
+                join(tmpdir(), 'semantic-release-jsr-'),
             );
-            const filePath = join(tmpDir, "package.json");
-
-            afterEach(async () => {
-                await rm(tmpDir, { recursive: true, force: true });
-            });
-
-            const mockFile = `{ "version": "1.2.3" }`;
-
-            await writeFile(filePath, mockFile, "utf8");
-
-            const context = {
-                nextRelease: {
-                    version: "1.2.4",
-                },
-                logger: {
-                    log: () => {},
-                },
-            } as never;
-
-            await updateVersionJson(filePath, context);
-            const updatedFile = await readFile(filePath, "utf8");
-
-            assert.strictEqual(updatedFile, `{ "version": "1.2.4" }`);
+            filePath = join(tmpDir, 'package.json');
         });
 
-        it("should skip when version is already up to date", async function () {
-            const tmpDir = await mkdtemp(
-                join(tmpdir(), "semantic-release-jsr-"),
-            );
-            const filePath = join(tmpDir, "package.json");
+        afterEach(async () => {
+            await rm(tmpDir, { recursive: true, force: true });
+        });
 
-            afterEach(async () => {
-                await rm(tmpDir, { recursive: true, force: true });
+        describe('different version', function () {
+            it('should update version if they are different', async function () {
+                const mockFile = '{ "version": "1.2.3" }';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                const context = {
+                    nextRelease: {
+                        version: '1.2.4',
+                    },
+                    logger: {
+                        log: () => {},
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, '{ "version": "1.2.4" }');
             });
 
-            const mockFile = `{ "version": "1.2.3" }`;
+            it('should update version if they are different (no whitespace)', async function () {
+                const mockFile = '{"version":"1.2.3"}';
 
-            await writeFile(filePath, mockFile, "utf8");
+                await writeFile(filePath, mockFile, 'utf8');
 
-            let matched = false;
-            const context = {
-                nextRelease: {
-                    version: "1.2.3",
-                },
-                logger: {
-                    log: (msg?: any) => {
-                        if (typeof msg === "string") {
-                            const match = msg.match(
-                                /Skipped, (.+) is already up to date/,
-                            );
-                            if (match) {
-                                assert.strictEqual(match[1], filePath);
-                                matched = true;
-                            }
-                        }
+                const context = {
+                    nextRelease: {
+                        version: '1.2.4',
                     },
-                },
-            } as never;
+                    logger: {
+                        log: () => {},
+                    },
+                } as never;
 
-            await updateVersionJson(filePath, context);
-            const updatedFile = await readFile(filePath, "utf8");
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
 
-            assert.strictEqual(updatedFile, mockFile);
-            assert.ok(matched);
+                assert.strictEqual(updatedFile, '{"version":"1.2.4"}');
+            });
+
+            it('should update version if they are different (mixed whitespace)', async function () {
+                const mockFile = '{"version"   :"1.2.3"   }';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                const context = {
+                    nextRelease: {
+                        version: '1.2.4',
+                    },
+                    logger: {
+                        log: () => {},
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, '{"version"   :"1.2.4"   }');
+            });
+        });
+        describe('same version', function () {
+
+            it('should skip when version is already up to date', async function () {
+
+                const mockFile = '{ "version": "1.2.3" }';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                let matched = false;
+                const context = {
+                    nextRelease: {
+                        version: '1.2.3',
+                    },
+                    logger: {
+                        log: (msg?: unknown) => {
+                            if (typeof msg === 'string') {
+                                const match = msg.match(
+                                    /Skipped, (.+) is already up to date/,
+                                );
+                                if (match) {
+                                    assert.strictEqual(match[1], filePath);
+                                    matched = true;
+                                }
+                            }
+                        },
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, mockFile);
+                assert.ok(matched);
+            });
         });
     });
 });


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?**
    - fix
- **What is the current behavior?**
    - When updating the version in a JSON file, the whole file is overwritten with indentation of 2 spaces. However, the user may have their own styling guide and this library should keep the indentation **as is** and only update the exact version.
- **What is the new behavior (if this is a feature change)?**
    - The `updateVersionJson` function only updates the version and keeps the previous indentation.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - No


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
