### PR TITLE
🎉 1.0.1

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,8 +95,12 @@ export async function updateVersionJson (file: string, context: VerifyReleaseCon
         return;
     }
 
-    json.version = context.nextRelease.version;
-    await writeFile(file, JSON.stringify(json, null, 2));
+    const versionRegex = /("version"\s*:\s*")(\d+\.\d+\.\d+)(")/;
+    const nextVersion = context.nextRelease.version;
+
+    const updatedContent = content.replace(versionRegex, `$1${nextVersion}$3`);
+
+    await writeFile(file, updatedContent, 'utf8');
     context.logger.log(`Wrote new version to ${file}`);
 }
 

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -4,8 +4,12 @@ import * as assert from 'node:assert';
 import {
     generatePublishResponse,
     NormalizedPluginConfig, parseConfig,
-    PublishResponseContext, removeTemporaryBinFolder
+    PublishResponseContext, removeTemporaryBinFolder,
+    updateVersionJson
 } from '../../src/index.ts';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 describe('Utils', function () {
     describe('parseConfig()', function () {
@@ -76,6 +80,116 @@ describe('Utils', function () {
             assert.deepStrictEqual(response, {
                 name: 'JSR.io',
                 url: 'https://jsr.io/@sebbo2002/ical-generator/versions'
+            });
+        });
+    });
+    describe('updateVersionJson()', async function () {
+        let tmpDir: string;
+        let filePath: string;
+
+        beforeEach(async () => {
+            tmpDir = await mkdtemp(
+                join(tmpdir(), 'semantic-release-jsr-'),
+            );
+            filePath = join(tmpDir, 'package.json');
+        });
+
+        afterEach(async () => {
+            await rm(tmpDir, { recursive: true, force: true });
+        });
+
+        describe('different version', function () {
+            it('should update version if they are different', async function () {
+                const mockFile = '{ "version": "1.2.3" }';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                const context = {
+                    nextRelease: {
+                        version: '1.2.4',
+                    },
+                    logger: {
+                        log: () => {},
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, '{ "version": "1.2.4" }');
+            });
+
+            it('should update version if they are different (no whitespace)', async function () {
+                const mockFile = '{"version":"1.2.3"}';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                const context = {
+                    nextRelease: {
+                        version: '1.2.4',
+                    },
+                    logger: {
+                        log: () => {},
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, '{"version":"1.2.4"}');
+            });
+
+            it('should update version if they are different (mixed whitespace)', async function () {
+                const mockFile = '{"version"   :"1.2.3"   }';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                const context = {
+                    nextRelease: {
+                        version: '1.2.4',
+                    },
+                    logger: {
+                        log: () => {},
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, '{"version"   :"1.2.4"   }');
+            });
+        });
+        describe('same version', function () {
+            it('should skip when version is already up to date', async function () {
+                const mockFile = '{ "version": "1.2.3" }';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                let matched = false;
+                const context = {
+                    nextRelease: {
+                        version: '1.2.3',
+                    },
+                    logger: {
+                        log: (msg?: unknown) => {
+                            if (typeof msg === 'string') {
+                                const match = msg.match(
+                                    /Skipped, (.+) is already up to date/,
+                                );
+                                if (match) {
+                                    assert.strictEqual(match[1], filePath);
+                                    matched = true;
+                                }
+                            }
+                        },
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, mockFile);
+                assert.ok(matched);
             });
         });
     });


### PR DESCRIPTION
### ℹ️ About this release
* **Version**: 1.0.1
* **Type**: patch
* **Last Release**: 1.0.0 (5/5/2024, 9:54:13 AM) [[?](https://github.com/sebbo2002/semantic-release-jsr/commit/94b1fb782e1600a5dc72017d53244a8169630fc2)]
* **Commits to merge**: 2 [[?](https://github.com/sebbo2002/semantic-release-jsr/compare/sebbo2002:94b1fb7...sebbo2002:50d8e2d)]
### 🐛 Bug Fixes

* Do not overwrite whole file when updating version ([50d8e2d](https://github.com/sebbo2002/semantic-release-jsr/commit/50d8e2d38dd34325c7dfd0675869c883f7aefe59)), closes [#10](https://github.com/sebbo2002/semantic-release-jsr/issues/10)