### PR TITLE
fix: add version number to logs for easier debugging

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,7 +87,8 @@ export async function updateVersionJson (file: string, context: VerifyReleaseCon
         return;
     }
 
-    context.logger.log(`Updating version in ${file}`);
+    const nextVersion = context.nextRelease.version;
+    context.logger.log(`Updating version ${nextVersion} in ${file}`);
     const content = await readFile(file, 'utf8');
     const json = JSON.parse(content);
     if (json.version === context.nextRelease.version) {
@@ -96,12 +97,11 @@ export async function updateVersionJson (file: string, context: VerifyReleaseCon
     }
 
     const versionRegex = /("version"\s*:\s*")(\d+\.\d+\.\d+)(")/;
-    const nextVersion = context.nextRelease.version;
 
     const updatedContent = content.replace(versionRegex, `$1${nextVersion}$3`);
 
     await writeFile(file, updatedContent, 'utf8');
-    context.logger.log(`Wrote new version to ${file}`);
+    context.logger.log(`Wrote new version ${nextVersion} to ${file}`);
 }
 
 export async function publish (config: NormalizedPluginConfig, context: VerifyConditionsContext): Promise<void> {


### PR DESCRIPTION

### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Minor feature – adds version number in logs.
- **What is the current behavior?** (You can also link to an open issue here)
    - The next version is not printed in the logs, making it harder to know what the plugin has detected as the next version.
- **What is the new behavior (if this is a feature change)?**
    - The logs will now print the version number/
- **Does this PR introduce a breaking change?**
    - None
- **Other information**:
    - This is to make https://github.com/sebbo2002/semantic-release-jsr/issues/13 easier to debug.


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
