### PR TITLE
fix: make sure beta version values are also correctly parsed in `version` field

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,7 +95,7 @@ export async function updateVersionJson (file: string, context: VerifyReleaseCon
         return;
     }
 
-    const versionRegex = /("version"\s*:\s*")(\d+\.\d+\.\d+)(")/;
+    const versionRegex = /^([\s\S]*"version"\s*:\s*")([^"]+)("[\s\S]*$)/;
     const nextVersion = context.nextRelease.version;
 
     const updatedContent = content.replace(versionRegex, `$1${nextVersion}$3`);

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -158,6 +158,27 @@ describe('Utils', function () {
 
                 assert.strictEqual(updatedFile, '{"version"   :"1.2.4"   }');
             });
+
+            it('should update version if they are different (beta version)', async function () {
+                const mockFile = '{ "version": "1.2.3-beta.3" }';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                const context = {
+                    nextRelease: {
+                        version: '1.2.3-beta.4',
+                    },
+                    logger: {
+                        log: () => {},
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, '{ "version": "1.2.3-beta.4" }');
+            });
+
         });
         describe('same version', function () {
             it('should skip when version is already up to date', async function () {


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Bug fix (fixes https://github.com/sebbo2002/semantic-release-jsr/issues/13)
- **What is the current behavior?**
    - See https://github.com/sebbo2002/semantic-release-jsr/issues/13
- **What is the new behavior (if this is a feature change)?**
    - This PR now correctly handles all possible values for the `version` field. The regex is now more robust, and handles _any_ kind of value for the `version` field.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - None
- **Other information**:
    - N/A


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
