### PR TITLE
fix(parseConfig): 🚨 make parameter context optional

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,9 +20,9 @@ import type {
 
 export async function parseConfig(
     config: PluginConfig,
-    context: PrepareContext | PublishContext | VerifyConditionsContext,
+    context?: PrepareContext | PublishContext | VerifyConditionsContext,
 ): Promise<NormalizedPluginConfig> {
-    const cwd = config.cwd || context.cwd || process.cwd();
+    const cwd = config.cwd || context?.cwd || process.cwd();
 
     let pkgJsonPath: null | string =
         config.pkgJsonPath || join(cwd, 'package.json');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
         "allowImportingTsExtensions": true,
+        "noEmit": true,
         "declaration": true,
         "esModuleInterop": true,
         "lib": ["es2023"],


### PR DESCRIPTION
Fixes the ts error `Expected 2 arguments, but got 1.` on the `parseConfig({})` call in `./test/lib/utils.ts`. Since the function uses a fallback to `process.cwd()` anyway


### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Lint fix (fixes a typescript error by the the `parseConfig({})` call in `./test/lib/utils.ts`)
- **What is the current behavior?** (You can also link to an open issue here)
    - 
- **What is the new behavior (if this is a feature change)?**
    - The typescript error `Expected 2 arguments, but got 1.`
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - None
- **Other information**:
    - Since the function uses a fallback to `process.cwd()` anyway, the `context` parameter can be optional, which resolves the typescript error in the test file without affecting any other behaviors.


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
