### PR TITLE
fix(updateVersionJson): 🩹 add skip on nullability of oldJson.version

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,6 +144,12 @@ export async function updateVersionJson(
     const nextVersion = context.nextRelease.version;
     const content = await readFile(file, 'utf8');
     const oldJson = JSON.parse(content);
+
+    if (oldJson.version == null) {
+        context.logger.log(`Skipped, ${file} does not have a version key`);
+        return;
+    }
+
     if (oldJson.version === nextVersion) {
         context.logger.log(`Skipped, ${file} is already up to date`);
         return;

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -224,8 +224,42 @@ describe('Utils', function () {
             });
         });
 
+        describe('missing version', function () {
+            it('should skip when version is missing', async function () {
+                const mockFile = '{}';
+
+                await writeFile(filePath, mockFile, 'utf8');
+
+                let matched = false;
+                const context = {
+                    logger: {
+                        log: (msg?: unknown) => {
+                            if (typeof msg === 'string') {
+                                const match = msg.match(
+                                    /Skipped, (.+) does not have a version key/,
+                                );
+                                if (match) {
+                                    assert.strictEqual(match[1], filePath);
+                                    matched = true;
+                                }
+                            }
+                        },
+                    },
+                    nextRelease: {
+                        version: '1.2.3',
+                    },
+                } as never;
+
+                await updateVersionJson(filePath, context);
+                const updatedFile = await readFile(filePath, 'utf8');
+
+                assert.strictEqual(updatedFile, mockFile);
+                assert.ok(matched);
+            });
+        });
+
         it('should throw an error if the version could not be replaced', async function () {
-            const mockFile = '{}';
+            const mockFile = '{ "version": {} }';
             await writeFile(filePath, mockFile, 'utf8');
 
             const context = {


### PR DESCRIPTION
 Addresses the edge case where the `version` key is not present in the .json config file

### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Bug fix (fixes: https://github.com/sebbo2002/semantic-release-jsr/issues/53)
- **What is the current behavior?** (You can also link to an open issue here)
    - See https://github.com/sebbo2002/semantic-release-jsr/issues/53
- **What is the new behavior (if this is a feature change)?**
    - No longer throws when `'version'` key is missing in the .json file, but skips the version update instead.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - None
- **Other information**:
    - This issue might often occur due to the lack of a package.json in the root directory of the jsr or deno projects. However, the function does not throw an error if the package.json is missing, but rather when one exists without a `version` key. In my case, this happens because in my workflow I install the plugin using npm, which creates a package.json accordingly at the runner's project root. But, that package.json will have no `version` key because the project will not have been previously initialized by npm.
    - At first, I temporarily solved this issue by explicitly configuring the path to the package.json in the plugin config to point to `./deno.json`
    - But, It might also be solved by executing `npm init` on the runner before the semantic-release job.
    - In my opinion, I don't see a reason of updating the version in all three .json files, but I might be missing something. Which is why skipping the file that lacks a `version` key is the safest addition to the code I can propose.
 
 ```json
{
  "$schema": "https://json.schemastore.org/semantic-release",
  "plugins": [
    "@semantic-release/commit-analyzer",
    "@semantic-release/release-notes-generator",
    "@semantic-release/github",
    [
      "@sebbo2002/semantic-release-jsr",
      {
        "pkgJsonPath": "./deno.json"
      }
    ]
  ]
}
```

### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
