### PR TITLE
fix: restore semantic-release plugin loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
     },
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.cjs"
+        "require": "./dist/plugin.cjs"
     },
     "files": [
         "/dist"
     ],
     "homepage": "https://github.com/sebbo2002/semantic-release-jsr#readme",
     "license": "MIT",
-    "main": "./dist/index.cjs",
+    "main": "./dist/plugin.cjs",
     "module": "./dist/index.mjs",
     "name": "@sebbo2002/semantic-release-jsr",
     "repository": {

--- a/src/plugin.cjs
+++ b/src/plugin.cjs
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const plugin = require('./index.cjs');
+
+module.exports = { ...plugin };

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsdown';
 
 const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
 export default defineConfig({
+    copy: ['src/plugin.cjs'],
     dts: true,
     entry: ['src/index.ts'],
     external: [


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
    - Fixes #153.
    - In v4, the CommonJS bundle generated by tsdown is dynamically imported by semantic-release as an object tagged as `Module`. semantic-release rejects that value as an invalid plugin configuration.
- **What is the new behavior (if this is a feature change)?**
    - CommonJS consumers and semantic-release now resolve to a tiny CJS wrapper that exports a plain object copied from `dist/index.cjs`.
    - The ESM export remains unchanged.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - No.
- **Other information**:
    - Verified that `await import("./dist/plugin.cjs")` returns a plain object and exposes the expected semantic-release lifecycle hooks.
    - Verified a packed tarball with `semantic-release@25.0.3` and a string plugin config. semantic-release successfully loaded `verifyConditions`, `prepare`, `publish`, `success`, and `fail` from `@sebbo2002/semantic-release-jsr`; the dry run then failed later at `git ls-remote` against the dummy repository URL, which is unrelated to plugin loading.

### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)

Validation run:

- `npm run lint`
- `npm test`
- `npm run build`
- `npm pack --pack-destination /private/tmp`
- Packed consumer smoke test with `semantic-release@25.0.3`
